### PR TITLE
PER-205 updated local adapter to return null

### DIFF
--- a/file-adapters/kinetic-filehub-adapter-local/pom.xml
+++ b/file-adapters/kinetic-filehub-adapter-local/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kineticdata.filehub.adapters.local</groupId>
     <artifactId>kinetic-filehub-adapter-local</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
     <scm>
         <connection>scm:git:https://github.com/kineticdata/kinetic-filehub-adapter-local.git</connection>

--- a/file-adapters/kinetic-filehub-adapter-local/src/main/java/com/kineticdata/filehub/adapters/local/LocalFilestoreAdapter.java
+++ b/file-adapters/kinetic-filehub-adapter-local/src/main/java/com/kineticdata/filehub/adapters/local/LocalFilestoreAdapter.java
@@ -158,7 +158,7 @@ public class LocalFilestoreAdapter implements FilestoreAdapter {
         // Concatenate the document root and root-relative path segments
         Path absolutePath = Paths.get(filestoreRootPath.toString(), relativePath.toString()).toAbsolutePath();
         // Return a new local document
-        return new LocalDocument(filestoreRootPath, absolutePath);
+        return Files.exists(absolutePath) ? new LocalDocument(filestoreRootPath, absolutePath) : null;
     }
 
     @Override

--- a/file-adapters/kinetic-filehub-adapter-local/src/test/java/com/kineticdata/filehub/adapters/local/LocalFilestoreAdapterTest.java
+++ b/file-adapters/kinetic-filehub-adapter-local/src/test/java/com/kineticdata/filehub/adapters/local/LocalFilestoreAdapterTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.TreeSet;
 import org.apache.tika.io.IOUtils;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -57,6 +58,12 @@ public class LocalFilestoreAdapterTest {
         assertEquals("text/plain", document.getContentType());
         assertEquals("subdirectory.txt", document.getName());
         assertEquals((Long)31L, document.getSizeInBytes());
+    }
+        
+    @Test
+    public void test_getDocument_MissingFile() throws Exception {
+        LocalDocument document = adapter.getDocument("missing.txt");
+        assertNull(document);
     }
     
     @Test


### PR DESCRIPTION
If a file resource was requested that resulted in a FileNotFound exception
the adapter was throwing an exception.  This cause the Agent to throw a 500.
A better result is for null to be returned from the adapter and the Agent
returns a 404.