### PR TITLE
Added support for custom endpoint and regions set to jcloud properites

### DIFF
--- a/file-adapters/kinetic-filehub-adapter-cloud/pom.xml
+++ b/file-adapters/kinetic-filehub-adapter-cloud/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kineticdata.filehub.adapters.cloud</groupId>
     <artifactId>kinetic-filehub-adapter-cloud</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
     <scm>
         <connection>scm:git:https://github.com/KineticCommunity/kinetic-filehub-adapter-cloud.git</connection>
@@ -137,7 +137,7 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 </project>

--- a/file-adapters/kinetic-filehub-adapter-cloud/pom.xml
+++ b/file-adapters/kinetic-filehub-adapter-cloud/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kineticdata.filehub.adapters.cloud</groupId>
     <artifactId>kinetic-filehub-adapter-cloud</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
     <scm>
         <connection>scm:git:https://github.com/KineticCommunity/kinetic-filehub-adapter-cloud.git</connection>

--- a/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
+++ b/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
@@ -104,6 +104,7 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
     protected BlobStoreContext buildBlobStoreContext() {
         java.util.Properties overrides = new java.util.Properties();
         String region = properties.getValue(Properties.REGION);
+        String endpoint = "https://s3-"+region.trim()+".amazonaws.com"
 
         if (region != null && !region.isEmpty()) {
             overrides.setProperty("aws-s3.endpoint", endpoint);

--- a/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
+++ b/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
@@ -104,12 +104,8 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
     protected BlobStoreContext buildBlobStoreContext() {
         java.util.Properties overrides = new java.util.Properties();
         String region = properties.getValue(Properties.REGION);
-        String endpoint = null;
 
         if (region != null && !region.isEmpty()) {
-            if(endpoint == null){
-                endpoint = "https://s3-"+region.trim()+".amazonaws.com";
-            }
             overrides.setProperty("aws-s3.endpoint", endpoint);
             overrides.setProperty("jclouds.regions", region.trim());
             overrides.setProperty("jclouds.region." + region.trim() + ".endpoint", endpoint);

--- a/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
+++ b/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
@@ -116,11 +116,11 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
         }
 
         return ContextBuilder.newBuilder("aws-s3")
-                .credentials(
-                    properties.getValue(Properties.ACCESS_KEY),
-                    properties.getValue(Properties.SECRET_ACCESS_KEY))
-                .overrides(overrides)
-                .buildView(BlobStoreContext.class);
+            .credentials(
+                properties.getValue(Properties.ACCESS_KEY),
+                properties.getValue(Properties.SECRET_ACCESS_KEY))
+            .overrides(overrides)
+            .buildView(BlobStoreContext.class);
     }
 
     @Override

--- a/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
+++ b/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
@@ -104,9 +104,9 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
     protected BlobStoreContext buildBlobStoreContext() {
         java.util.Properties overrides = new java.util.Properties();
         String region = properties.getValue(Properties.REGION);
-        String endpoint = "https://s3-"+region.trim()+".amazonaws.com"
 
         if (region != null && !region.isEmpty()) {
+            String endpoint = "https://s3-"+region.trim()+".amazonaws.com"
             overrides.setProperty("aws-s3.endpoint", endpoint);
             overrides.setProperty("jclouds.regions", region.trim());
             overrides.setProperty("jclouds.region." + region.trim() + ".endpoint", endpoint);

--- a/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
+++ b/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
@@ -32,7 +32,6 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
         public static final String SECRET_ACCESS_KEY = "Secret Access Key";
         public static final String REGION = "Region";
         public static final String ROOT_FOLDER = "Root Folder";
-        public static final String CUSTOM_ENDPOINT = "Custom Endpoint";
     }
     
     /** 
@@ -56,8 +55,6 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
         new ConfigurableProperty(Properties.REGION)
             .setIsRequired(false),
         new ConfigurableProperty(Properties.ROOT_FOLDER)
-            .setIsRequired(false),
-        new ConfigurableProperty(Properties.CUSTOM_ENDPOINT)
             .setIsRequired(false)
     );
     
@@ -107,13 +104,8 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
     protected BlobStoreContext buildBlobStoreContext() {
         java.util.Properties overrides = new java.util.Properties();
         String region = properties.getValue(Properties.REGION);
-        String customEndpoint = properties.getValue(Properties.CUSTOM_ENDPOINT);
         String endpoint = null;
 
-
-        if (customEndpoint !=null && !customEndpoint.isEmpty()) {
-            endpoint = customEndpoint;
-        }
         if (region != null && !region.isEmpty()) {
             if(endpoint == null){
                 endpoint = "https://s3-"+region.trim()+".amazonaws.com";

--- a/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
+++ b/file-adapters/kinetic-filehub-adapter-cloud/src/main/java/com/kineticdata/filehub/adapters/cloud/CloudFilestoreAmazonS3Adapter.java
@@ -117,8 +117,8 @@ public class CloudFilestoreAmazonS3Adapter extends CloudFilestoreAdapter {
 
         return ContextBuilder.newBuilder("aws-s3")
                 .credentials(
-                        properties.getValue(Properties.ACCESS_KEY),
-                        properties.getValue(Properties.SECRET_ACCESS_KEY))
+                    properties.getValue(Properties.ACCESS_KEY),
+                    properties.getValue(Properties.SECRET_ACCESS_KEY))
                 .overrides(overrides)
                 .buildView(BlobStoreContext.class);
     }


### PR DESCRIPTION
## Summary

This change adds standard AWS S3 region configuration support to existing endpoint generation capability.

## Changes

  - Configure the following jclouds override properties when applicable:
    - `aws-s3.endpoint`
    - `jclouds.regions`
    - `jclouds.region.<region>.endpoint`